### PR TITLE
Update express for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "server.js",
   "dependencies": {
-    "express": "~4.0.0",
+    "express": "~4.17.1",
     "body-parser": "~1.0.1",
     "winston": "2.2.0",
     "timezonecomplete": "5.4.1",


### PR DESCRIPTION
Saw the warning about the older insecure version of express. 
We might want to enable greenkeeper or something similar on our repos to keep dependencies up to date.